### PR TITLE
this should fix part of the enyo.ready problem

### DIFF
--- a/source/enyo-editor/deimos/designer/designerFrame/designerFrame.js
+++ b/source/enyo-editor/deimos/designer/designerFrame/designerFrame.js
@@ -126,7 +126,7 @@ enyo.kind({
 		// Allow overriding kind definitions
 		enyo.kind.allowOverride = true;
 		// Disable enyo.ready
-			if(enyo.ready){
+		if(enyo.ready){
 			enyo.ready = enyo.nop;
 		}
 		// Disable autoStart/autoRender features of enyo.Application

--- a/source/enyo-editor/deimos/designer/designerFrame/designerFrame.js
+++ b/source/enyo-editor/deimos/designer/designerFrame/designerFrame.js
@@ -125,6 +125,10 @@ enyo.kind({
 	adjustFrameworkFeatures: function() {
 		// Allow overriding kind definitions
 		enyo.kind.allowOverride = true;
+		// Disable enyo.ready
+			if(enyo.ready){
+			enyo.ready = enyo.nop;
+		}
 		// Disable autoStart/autoRender features of enyo.Application
 		if (enyo.Application) {
 			enyo.Application.prototype.start = enyo.nop;


### PR DESCRIPTION
this should fix part of the enyo.ready problem

next you  find that the boot.js in the project enyo folder is a problem
you be getting error in the loader.js file  They change the boot.js file   in/at  about enyo 2.4. the 
enyo.load function got changed. the var    var domLoaded = false;   if set to true will let it load and work.

the work around are as follow.
1. change the var domLoaded = false;   to true  and edit project  then switch it back
2. and a new loader  (to boot.js in the project)  function (like i have done ares.load in ares-m )  this also need a patch to the designer frame to switch between the older 2.3 and the newer version.
3. do some type of pre processing of the data sent to the enyo.loader. i have not put any time in to figuring this out or if it would work.
